### PR TITLE
Fix a typo (probably?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and numbers are kept in their original form in the [`JsonString`][string] and
 are fully validated when parsed. **The net effect is significantly fewer
 allocations when parsing a JSON value.**
 
-[`JsonString`][string] implements `PartialCmp<&str>` such that if the
+[`JsonString`][string] implements `PartialEq<&str>` such that if the
 `JsonString` contains escape sequences, the comparison is handled correctly.
 Each `JsonString` tracks its decoded length as well as whether any escapes are
 present, allowing this comparison to be very efficient.


### PR DESCRIPTION
I'd thought `PartialCmp` was meant to be `PartialOrd`, but `JsonString` doesn't implement it so it was probably `PartialEq`.