### PR TITLE
Fix documentation for latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 )]
 #![deny(unsafe_code)]
 #![no_std]
-#![cfg_attr(any(docsrs, feature = "nightly"), feature(doc_auto_cfg))]
+#![cfg_attr(any(docsrs, feature = "nightly"), feature(doc_cfg))]
 
 #[cfg(any(feature = "std", test))]
 extern crate std;


### PR DESCRIPTION
The latest nightly toolchain removes `doc_auto_cfg` and merges it into `doc_cfg`. Without this change, the crate cannot be documented on the latest nightly toolchain anymore.